### PR TITLE
Removed Cortex-A from comment

### DIFF
--- a/.github/workflows/runtest.yaml
+++ b/.github/workflows/runtest.yaml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
    CI_test_run: 
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout

--- a/ARM.CMSIS-CV.pdsc
+++ b/ARM.CMSIS-CV.pdsc
@@ -41,7 +41,7 @@
   <components>
     <!-- CMSIS-CV component -->
     <component Cclass="CMSIS" Cgroup="CV" Cvariant="Source"  Cversion="0.0.0" isDefaultVariant="true" condition="CMSISDSPLIB">
-      <description>CMSIS-CV Library for Cortex-M and Cortex-A</description>
+      <description>CMSIS-CV Library for Cortex-M</description>
       <files>
         <!-- CPU independent -->
         <file category="doc"      name="Documentation/html/index.html"/>

--- a/Documentation/Doxygen/src/mainpage.md
+++ b/Documentation/Doxygen/src/mainpage.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This user manual describes the CMSIS CV software library, a suite of common computer vision processing functions for use on Cortex-M and Cortex-A processor based devices.
+This user manual describes the CMSIS CV software library, a suite of common computer vision processing functions for use on Cortex-M processor based devices.
 
 It is a work in progress that has just started. API is not yet stable and will evolve for a few releases.
 

--- a/Include/arm_cv.h
+++ b/Include/arm_cv.h
@@ -4,7 +4,7 @@
  * Description:  General header from CMSIS-CV
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.

--- a/Include/arm_cv_common.h
+++ b/Include/arm_cv_common.h
@@ -4,7 +4,7 @@
  * Description:  Common declarations for CMSIS-CV
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.

--- a/Include/arm_cv_types.h
+++ b/Include/arm_cv_types.h
@@ -4,7 +4,7 @@
  * Description:  Datatypes CMSIS-CV
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.

--- a/Include/arm_cv_types_f16.h
+++ b/Include/arm_cv_types_f16.h
@@ -4,7 +4,7 @@
  * Description:  float16 types for CMSIS-CV
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.

--- a/Include/cv/color_transforms.h
+++ b/Include/cv/color_transforms.h
@@ -4,7 +4,7 @@
  * Description:  Color transforms for CMSIS-CV
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.

--- a/Include/cv/feature_detection.h
+++ b/Include/cv/feature_detection.h
@@ -4,7 +4,7 @@
  * Description:  Feature detection for CMSIS-CV
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.

--- a/Include/cv/image_transforms.h
+++ b/Include/cv/image_transforms.h
@@ -4,7 +4,7 @@
  * Description:  Image transformations for CMSIS-CV
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.

--- a/Include/cv/linear_filters.h
+++ b/Include/cv/linear_filters.h
@@ -4,7 +4,7 @@
  * Description:  Linear 2D filters for CMSIS-CV
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.

--- a/PrivateInclude/arm_image_resize_common.h
+++ b/PrivateInclude/arm_image_resize_common.h
@@ -3,7 +3,7 @@
  * Title:        arm_image_resize_common.h
  * Description:  Common declarations for CMSIS-CV image resize functions
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2024 Himax Technologies, Inc. or its affiliates. All rights reserved.

--- a/PrivateInclude/arm_linear_filter_common.h
+++ b/PrivateInclude/arm_linear_filter_common.h
@@ -3,7 +3,7 @@
  * Title:        arm_image_resize_common.h
  * Description:  Common declarations for CMSIS-CV image resize functions
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2024 Himax Technologies, Inc. or its affiliates. All rights reserved.

--- a/PrivateInclude/arm_linear_filter_generator.h
+++ b/PrivateInclude/arm_linear_filter_generator.h
@@ -4,7 +4,7 @@
  * Description:  common code used by different linear filter functions
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 CMSIS-CV is an optimized computer vision library for embedded systems.
 
-It provides optimized compute kernels for Cortex-M and for Cortex-A.
+It provides optimized compute kernels for Cortex-M.
 
 Different variants are available according to the core and most of the functions are using a vectorized version when the Helium or Neon extension is available.
 

--- a/Source/ColorTransforms/arm_bgr_8U3C_to_gray8.c
+++ b/Source/ColorTransforms/arm_bgr_8U3C_to_gray8.c
@@ -3,7 +3,7 @@
  * Title:        arm_bgr_8U3C_to_gray8
  * Description:  Convertion of planar BGR to gray8
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2024 ARM Limited or its affiliates. All rights reserved.

--- a/Source/ColorTransforms/arm_bgr_8U3C_to_rgb24.c
+++ b/Source/ColorTransforms/arm_bgr_8U3C_to_rgb24.c
@@ -3,7 +3,7 @@
  * Title:        arm_bgr_8U3C_to_rgb24
  * Description:  Convertion of planar BGR to RGB24
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2024 ARM Limited or its affiliates. All rights reserved.

--- a/Source/ColorTransforms/arm_gray8_to_rgb24.c
+++ b/Source/ColorTransforms/arm_gray8_to_rgb24.c
@@ -3,7 +3,7 @@
  * Title:        arm_gray8_to_rgb24
  * Description:  Convertion of gray8 to rgb24
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2024 ARM Limited or its affiliates. All rights reserved.

--- a/Source/ColorTransforms/arm_rgb24_to_gray8.c
+++ b/Source/ColorTransforms/arm_rgb24_to_gray8.c
@@ -3,7 +3,7 @@
  * Title:        arm_rbg24_to_gray8
  * Description:  Convertion of rgb24 to gray8
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2024 ARM Limited or its affiliates. All rights reserved.

--- a/Source/ColorTransforms/arm_yuv420_to_gray8.c
+++ b/Source/ColorTransforms/arm_yuv420_to_gray8.c
@@ -3,7 +3,7 @@
  * Title:        arm_yuv240_to_gray8
  * Description:  Convertion of yuv240 to gray8
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2024 ARM Limited or its affiliates. All rights reserved.

--- a/Source/ColorTransforms/arm_yuv420_to_rgb24.c
+++ b/Source/ColorTransforms/arm_yuv420_to_rgb24.c
@@ -3,7 +3,7 @@
  * Title:        arm_yuv240_to_rgb24
  * Description:  Convertion of yuv240 to rgb24
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2024 ARM Limited or its affiliates. All rights reserved.

--- a/Source/FeatureDetection/arm_cannysobel.c
+++ b/Source/FeatureDetection/arm_cannysobel.c
@@ -5,7 +5,7 @@
  * filter)
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.

--- a/Source/ImageTransforms/arm_crop_gray8.c
+++ b/Source/ImageTransforms/arm_crop_gray8.c
@@ -3,7 +3,7 @@
  * Title:        arm_crop_gray8
  * Description:  Cropping of grayscale image
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2024 ARM Limited or its affiliates. All rights reserved.

--- a/Source/ImageTransforms/arm_crop_rgb24.c
+++ b/Source/ImageTransforms/arm_crop_rgb24.c
@@ -3,7 +3,7 @@
  * Title:        arm_crop_gray8
  * Description:  Cropping of grayscale image
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2024 ARM Limited or its affiliates. All rights reserved.

--- a/Source/ImageTransforms/arm_image_resize_bgr_8U3C_f32.c
+++ b/Source/ImageTransforms/arm_image_resize_bgr_8U3C_f32.c
@@ -3,7 +3,7 @@
  * Title:        arm_image_resize_bgr_8U3C
  * Description:  image resize of planar BGR
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2024 Himax Technologies, Inc. or its affiliates. All rights reserved.

--- a/Source/ImageTransforms/arm_image_resize_bgr_8U3C_to_rgb24_f32.c
+++ b/Source/ImageTransforms/arm_image_resize_bgr_8U3C_to_rgb24_f32.c
@@ -3,7 +3,7 @@
  * Title:        arm_image_resize_bgr_8U3C_to_rgb24_f32
  * Description:  image resize of planar BGR8U3C to RGB24
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2024 Himax Technologies, Inc. or its affiliates. All rights reserved.

--- a/Source/ImageTransforms/arm_image_resize_common_f32.c
+++ b/Source/ImageTransforms/arm_image_resize_common_f32.c
@@ -3,7 +3,7 @@
  * Title:        arm_image_resize_common
  * Description:  common code used by different resize functions
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2024 Himax Technologies, Inc. or its affiliates. All rights reserved.

--- a/Source/ImageTransforms/arm_image_resize_gray8_f32.c
+++ b/Source/ImageTransforms/arm_image_resize_gray8_f32.c
@@ -3,7 +3,7 @@
  * Title:        arm_image_resize_gray8
  * Description:  image resize of gray8
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2024 Himax Technologies, Inc. or its affiliates. All rights reserved.

--- a/Source/LinearFilters/arm_gaussian.c
+++ b/Source/LinearFilters/arm_gaussian.c
@@ -5,7 +5,7 @@
  * filter
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.
@@ -27,7 +27,9 @@
 
 #include "cv/linear_filters.h"
 #include "dsp/basic_math_functions.h"
-#include "arm_acle.h"
+#include "dsp/none.h"
+
+
 // The kernel applied by this filter is [1,2,1]
 //                                      [2,4,2]
 //                                      [1,2,1]
@@ -37,7 +39,7 @@
 // This macro is in fact two operation at once,
 // first the conversion from q6 to uint8/q0
 // second the division per 16, necessary to have the sum of the coeficients in our gaussian equal to 1
-#define CONVERSION_GAUSSIAN_Q6TO_U8_AND_DIV_16(a) __ssat(((a) >> 10),16)
+#define CONVERSION_GAUSSIAN_Q6TO_U8_AND_DIV_16(a) __SSAT(((a) >> 10),16)
 
 // Apply a kernel [1,2,1] in q3 so [0x08,0x10,0x08] to the input data
 // This macro will be applied two time on each pixel.

--- a/Source/LinearFilters/arm_gaussian_5x5.c
+++ b/Source/LinearFilters/arm_gaussian_5x5.c
@@ -5,7 +5,7 @@
  * filter
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.
@@ -27,7 +27,9 @@
 
 #include "cv/linear_filters.h"
 #include "dsp/basic_math_functions.h"
-#include "arm_acle.h"
+#include "dsp/none.h"
+
+
 // The kernel applied by this filter is [1, 4, 6, 4, 1] /256
 //                                      [4,16,24,16, 4]
 //                                      [6,24,36,24, 6]
@@ -36,7 +38,7 @@
 // it also can be seen as applying the kernel [1,4,6,4,1] one time on the line and one time on the column sum is 256
 
 // Macro dividing the input value by 256, necessary to normalise the kernel of the gaussian
-#define DIV_256(a) __ssat(((a) >> 8), 16)
+#define DIV_256(a) __SSAT(((a) >> 8), 16)
 
 // Apply the kernel [1, 4, 6, 4, 1] to the input values
 #define VERTICAL_COMPUTE_SCALAR(data_0, data_1, data_2, data_3, data_4)                                                \

--- a/Source/LinearFilters/arm_gaussian_7x7_buffer_15.c
+++ b/Source/LinearFilters/arm_gaussian_7x7_buffer_15.c
@@ -5,7 +5,7 @@
  * filter
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.
@@ -27,7 +27,8 @@
 
 #include "cv/linear_filters.h"
 #include "dsp/basic_math_functions.h"
-#include "arm_acle.h"
+#include "dsp/none.h"
+
 // #define BUFFER_TYPE q15_t
 //  The kernel applied by this filter is [ 4, 14, 28, 36, 28, 14, 4] /4096
 //                                       [14, 49, 98,126, 98, 49,14]
@@ -41,7 +42,7 @@
 // 256
 
 // Macro dividing the input value by 256, necessary to normalise the kernel of the gaussian
-#define DIV_256(a) __ssat(((a) >> 8),16)
+#define DIV_256(a) __SSAT(((a) >> 8),16)
 
 // Apply the kernel [2, 7, 14, 18, 14, 7, 2] to the input values
 #define KERNEL_APPLICATION(data_0, data_1, data_2, data_3, data_4, data_5, data_6)                                     \
@@ -52,7 +53,7 @@
 // value of 64 * 255, the second application can lead to a max value of 64*64 ** 255 that can overflow int16 this shift
 // lead to a loss of precision in some cases
 #define VERTICAL_COMPUTE_SCALAR(data_0, data_1, data_2, data_3, data_4, data_5, data_6)                                \
-    __ssat(KERNEL_APPLICATION(data_0, data_1, data_2, data_3, data_4, data_5, data_6) >> 4, 16)
+    __SSAT(KERNEL_APPLICATION(data_0, data_1, data_2, data_3, data_4, data_5, data_6) >> 4, 16)
 
 // The horizontal computation consist of applying the kernel and shifting by 8 on the left. the sum of the coeficient of
 // the kernel is 4096, so shift by 12, but we already shifted by 4 in the vertical part

--- a/Source/LinearFilters/arm_gaussian_7x7_buffer_31.c
+++ b/Source/LinearFilters/arm_gaussian_7x7_buffer_31.c
@@ -5,7 +5,7 @@
  * filter
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.
@@ -27,7 +27,7 @@
 
 #include "cv/linear_filters.h"
 #include "dsp/basic_math_functions.h"
-#include "arm_acle.h"
+#include "dsp/none.h"
 
 // #define BUFFER_TYPE q15_t
 //  The kernel applied by this filter is [ 4, 14, 28, 36, 28, 14, 4] /4096
@@ -42,7 +42,7 @@
 // 256
 
 // Macro dividing the input value by 256, necessary to normalise the kernel of the gaussian
-#define DIV_256(a) __ssat(((a) >> 8), 32)
+#define DIV_256(a) __SSAT(((a) >> 8), 32)
 
 // Apply the kernel [2, 7, 14, 18, 14, 7, 2] to the input values
 #define KERNEL_APPLICATION(data_0, data_1, data_2, data_3, data_4, data_5, data_6)                                     \

--- a/Source/LinearFilters/arm_sobel_horizontal.c
+++ b/Source/LinearFilters/arm_sobel_horizontal.c
@@ -4,7 +4,7 @@
  * Description:  Sobel filter on y axis filter CMSIS-CV
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.

--- a/Source/LinearFilters/arm_sobel_vertical.c
+++ b/Source/LinearFilters/arm_sobel_vertical.c
@@ -4,7 +4,7 @@
  * Description:  Sobel filter on x axis filter CMSIS-CV
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- */
 /*
  * Copyright (C) 2014 ARM Limited or its affiliates. All rights reserved.

--- a/Testing/board/test_config.h
+++ b/Testing/board/test_config.h
@@ -1,7 +1,7 @@
 #ifndef TEST_CONFIG_H
 #define TEST_CONFIG_H
 
-#define TESTGROUP3
+#define TESTGROUP0
 
 #endif
 

--- a/Testing/browser/GenericNodes.h
+++ b/Testing/browser/GenericNodes.h
@@ -4,7 +4,7 @@
  * Description:  C++ support templates for the compute graph with static scheduler
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- 
  *
  * Copyright (C) 2021-2023 ARM Limited or its affiliates. All rights reserved.

--- a/Testing/browser/cg_status.h
+++ b/Testing/browser/cg_status.h
@@ -4,7 +4,7 @@
  * Description:  Error code for the Compute Graph
  *
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- 
  *
  * Copyright (C) 2021-2023 ARM Limited or its affiliates. All rights reserved.

--- a/Testing/browser/stream/AppNodes.h
+++ b/Testing/browser/stream/AppNodes.h
@@ -3,7 +3,7 @@
  * Title:        AppNodes.h
  * Description:  Application nodes for Example simple
  *
- * Target Processor: Cortex-M and Cortex-A cores
+ * Target Processor: Cortex-M
  * -------------------------------------------------------------------- 
 *
  * Copyright (C) 2021-2023 ARM Limited or its affiliates. All rights reserved.


### PR DESCRIPTION
Removed Cortex-A from comment
Use CMSIS-DSP intrinsics rather than arm_acle for better portability (and to re-enable the web build)